### PR TITLE
Upgrade escomplex

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "license": "BSD-2-Clause",
   "devDependencies": {
     "codecov.io": "~0.1.6",
-    "escomplex-js": "1.2.0",
+    "escomplex": "^2.0.0-alpha",
     "everything.js": "~1.0.3",
     "glob": "~7.1.0",
     "istanbul": "~0.4.0",
@@ -100,7 +100,7 @@
     "benchmark-parser": "node -expose_gc test/benchmark-parser.js",
     "benchmark-tokenizer": "node --expose_gc test/benchmark-tokenizer.js",
     "benchmark": "npm run benchmark-parser && npm run benchmark-tokenizer",
-    "codecov" : "istanbul report cobertura && codecov < ./coverage/cobertura-coverage.xml",
+    "codecov": "istanbul report cobertura && codecov < ./coverage/cobertura-coverage.xml",
     "downstream": "node test/downstream.js",
     "travis": "npm test",
     "circleci": "npm test && npm run codecov && npm run downstream",

--- a/test/check-complexity.js
+++ b/test/check-complexity.js
@@ -24,7 +24,7 @@
 
 'use strict';
 
-var escomplex = require('escomplex-js'),
+var escomplex = require('escomplex'),
     content = require('fs').readFileSync(require.resolve('../'), 'utf-8'),
     opt = { logicalor: false, switchcase: false },
     MAX = 24,


### PR DESCRIPTION
Use `escomplex-js` for complexity analyze since `escomplex` has been deprecated.